### PR TITLE
fix(@angular/cli): remove bootstrap dirname

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -46,33 +46,31 @@ require.extensions['.ts'] = function (m, filename) {
 //   lazy: true
 // });
 
-// If we're running locally, meaning npm linked. This is basically "developer mode".
-if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
-  const packages = require('./packages').packages;
+// We're running locally, meaning npm linked. This is basically "developer mode".
+const packages = require('./packages').packages;
 
-  // We mock the module loader so that we can fake our packages when running locally.
-  const Module = require('module');
-  const oldLoad = Module._load;
-  Module._load = function (request, parent) {
-    if (request.match(/ts-node/) && parent && parent.id && parent.id.match(/karma/)) {
-      throw new Error();
-    }
-    if (request in packages) {
-      return oldLoad.call(this, packages[request].main, parent);
-    } else if (request.startsWith('@angular/cli/')) {
-      // We allow deep imports (for now).
-      // TODO: move tests to inside @angular/cli package so they don't have to deep import.
-      const dir = path.dirname(parent.filename);
-      const newRequest = path.relative(dir, path.join(__dirname, '../packages', request));
-      return oldLoad.call(this, newRequest, parent);
+// We mock the module loader so that we can fake our packages when running locally.
+const Module = require('module');
+const oldLoad = Module._load;
+Module._load = function (request, parent) {
+  if (request.match(/ts-node/) && parent && parent.id && parent.id.match(/karma/)) {
+    throw new Error();
+  }
+  if (request in packages) {
+    return oldLoad.call(this, packages[request].main, parent);
+  } else if (request.startsWith('@angular/cli/')) {
+    // We allow deep imports (for now).
+    // TODO: move tests to inside @angular/cli package so they don't have to deep import.
+    const dir = path.dirname(parent.filename);
+    const newRequest = path.relative(dir, path.join(__dirname, '../packages', request));
+    return oldLoad.call(this, newRequest, parent);
+  } else {
+    let match = Object.keys(packages).find(pkgName => request.startsWith(pkgName + '/'));
+    if (match) {
+      const p = path.join(packages[match].root, request.substr(match.length));
+      return oldLoad.call(this, p, parent);
     } else {
-      let match = Object.keys(packages).find(pkgName => request.startsWith(pkgName + '/'));
-      if (match) {
-        const p = path.join(packages[match].root, request.substr(match.length));
-        return oldLoad.call(this, p, parent);
-      } else {
-        return oldLoad.apply(this, arguments);
-      }
+      return oldLoad.apply(this, arguments);
     }
-  };
-}
+  }
+};


### PR DESCRIPTION
The dirname check is causing problems when using WSL (Bash on Windows), due to the dirname being adapted to the WSL paths.

This causes the bootstrap to not correctly replace the local lib requests, which in turn causes `@ngtools/webpack` to not be able to detect the correct instance of `AoTPlugin` which leads to `Module build failed: TypeError: Cannot read property 'newLine' of undefined` errors.

It's also extraneous, since whenever we're running `bootstrap-local.ts` we're always in a linked state anyway.

Note: this is not the sole cause of `Module build failed: TypeError: Cannot read property 'newLine' of undefined` errors, they are generally due to multiple installed versions of `@ngtools/webpack` (which can be seen with `npm ls @ngtools/webpack`).